### PR TITLE
Improve docstring return types

### DIFF
--- a/src/pydoc_markdown_nuxt/renderer.py
+++ b/src/pydoc_markdown_nuxt/renderer.py
@@ -840,7 +840,18 @@ class NuxtRenderer(Renderer):
         return navigation
 
     def _get_icon_key(self, primary_object: t.Optional[docspec.ApiObject]) -> str:
-        """Return the icon key for a given API object."""
+        """Return the icon key for a given API object.
+
+        Args:
+            primary_object (t.Optional[docspec.ApiObject]): The API object for which
+                the icon key is being determined. Can be a module, class, function,
+                variable, or None.
+
+        Returns:
+            str: The icon key corresponding to the type of the API object. Returns
+            "module" for modules, "class" for classes, "function" for functions,
+            "variable" for variables, and "page" for None or unrecognized types.
+        """
         if not primary_object:
             return "page"
         if isinstance(primary_object, docspec.Module):

--- a/src/pydoc_markdown_nuxt/renderer.py
+++ b/src/pydoc_markdown_nuxt/renderer.py
@@ -97,7 +97,16 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         self._maybe_render_docstring(fp, obj)
 
     def _maybe_render_source(self, fp: t.TextIO, obj: docspec.ApiObject, render_view_source: bool, position: str):
-        """Helper to render source link before or after signature."""
+        """Render the source link before or after the signature.
+
+        Args:
+            fp (t.TextIO): File-like object where the output is written.
+            obj (docspec.ApiObject): API object being rendered.
+            render_view_source (bool): Whether the source link should be
+                rendered.
+            position (str): Either ``"before signature"`` or
+                ``"after signature"``.
+        """
         if not render_view_source:
             return
         url = self.source_linker.get_source_url(obj) if self.source_linker else None
@@ -106,7 +115,13 @@ class MDCMarkdownRenderer(MarkdownRenderer):
             fp.write(source_string + "\n\n")
 
     def _maybe_render_docstring(self, fp: t.TextIO, obj: docspec.ApiObject):
-        """Helper to process and render docstring."""
+        """Process and render an object's docstring.
+
+        Args:
+            fp (t.TextIO): File-like object where the output is written.
+            obj (docspec.ApiObject): API object whose docstring is being
+                rendered.
+        """
         if not obj.docstring:
             return
         docstring_content = obj.docstring.content
@@ -121,7 +136,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         fp.write("\n\n")
 
     def _process_docstring_for_mdc(self, docstring: str) -> str:
-        """Process docstring to convert various sections to MDC components."""
+        """Convert conventional docstring sections to MDC components.
+
+        Args:
+            docstring (str): Raw docstring text.
+
+        Returns:
+            str: The transformed docstring where supported sections are
+            replaced with MDC components.
+        """
 
         # Process in order of specificity
         processed = docstring
@@ -150,7 +173,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return processed
 
     def _convert_code_blocks_to_mdc(self, docstring: str) -> str:
-        """Convert multiple code blocks to MDC code groups."""
+        """Convert multiple code blocks to an MDC code group.
+
+        Args:
+            docstring (str): The docstring text to process.
+
+        Returns:
+            str: The docstring with consecutive code blocks replaced by a
+            single MDC code group component when applicable.
+        """
         import re
 
         # Pattern to match multiple consecutive code blocks
@@ -214,7 +245,17 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return result
 
     def _convert_section_to_mdc(self, docstring: str, section_name: str, component_key: str) -> str:
-        """Convert a docstring section with list items to MDC component."""
+        """Convert a docstring section with list items to an MDC component.
+
+        Args:
+            docstring (str): The docstring text to search in.
+            section_name (str): Name of the section (e.g. ``"Arguments"``).
+            component_key (str): Key used to look up the MDC component name.
+
+        Returns:
+            str: The docstring with the specified section replaced by an MDC
+            component if it contains items.
+        """
         import re
 
         # Pattern to match sections like **Arguments**: with list items
@@ -258,7 +299,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_section, docstring, flags=re.MULTILINE)
 
     def _convert_returns_to_mdc(self, docstring: str) -> str:
-        """Convert Returns sections to MDC components."""
+        """Convert ``Returns`` sections to MDC components.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring with ``Returns`` sections wrapped in the
+            configured MDC component.
+        """
         import re
 
         # Pattern to match **Returns**: sections
@@ -274,7 +323,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_returns, docstring, flags=re.DOTALL)
 
     def _convert_examples_to_mdc(self, docstring: str) -> str:
-        """Convert Examples sections to MDC code groups."""
+        """Convert ``Examples`` sections to MDC code groups.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring with ``Examples`` sections converted to MDC code
+            group components when code blocks are detected.
+        """
         import re
 
         # Pattern to match **Examples**: sections that contain code
@@ -303,7 +360,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_examples, docstring, flags=re.DOTALL)
 
     def _convert_notes_to_mdc(self, docstring: str) -> str:
-        """Convert Notes sections to alert components."""
+        """Convert ``Notes`` sections to alert components.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring where ``Notes`` sections are replaced by MDC
+            alert components.
+        """
         import re
 
         pattern = r"\*\*Notes?\*\*:\s*\n\n(.*?)(?=\n\n\*\*|\Z)"
@@ -316,7 +381,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_notes, docstring, flags=re.DOTALL)
 
     def _convert_warnings_to_mdc(self, docstring: str) -> str:
-        """Convert Warnings sections to alert components."""
+        """Convert ``Warnings`` sections to alert components.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring where ``Warnings`` sections are replaced by MDC
+            alert components.
+        """
         import re
 
         pattern = r"\*\*Warnings?\*\*:\s*\n\n(.*?)(?=\n\n\*\*|\Z)"
@@ -329,7 +402,14 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_warnings, docstring, flags=re.DOTALL)
 
     def _convert_raises_to_mdc(self, docstring: str) -> str:
-        """Convert Raises sections to callout components."""
+        """Convert ``Raises`` sections to callout components.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring where ``Raises`` sections are replaced with MDC callout components summarizing the exceptions raised.
+        """
         import re
 
         pattern = r"\*\*Raises\*\*:\s*\n\n(.*?)(?=\n\n\*\*|\Z)"
@@ -359,7 +439,15 @@ class MDCMarkdownRenderer(MarkdownRenderer):
         return re.sub(pattern, replace_raises, docstring, flags=re.DOTALL)
 
     def _convert_arguments_to_mdc(self, docstring: str) -> str:
-        """Convert Arguments sections to MDC components."""
+        """Convert ``Arguments`` sections to MDC components.
+
+        Args:
+            docstring (str): Docstring text to transform.
+
+        Returns:
+            str: The docstring with ``Arguments`` sections converted to the
+            configured MDC component.
+        """
         return self._convert_section_to_mdc(docstring, "Arguments", "arguments")
 
 
@@ -377,7 +465,8 @@ class NuxtContentResolver(MarkdownReferenceResolver):
         Initialize the resolver.
 
         Args:
-            base_path: The base URL path for the API documentation (e.g., '/docs/api')
+            base_path (str): The base URL path for the API documentation
+                (e.g., ``'/docs/api'``)
         """
         self.base_path = base_path.strip("/")
 
@@ -402,11 +491,12 @@ class NuxtContentResolver(MarkdownReferenceResolver):
         Resolve a reference to a Markdown file path for Nuxt Content.
 
         Args:
-            scope: The current API object scope.
-            ref: The reference string (e.g., 'my.module.MyClass' or a relative reference).
+            scope (docspec.ApiObject): The current API object scope.
+            ref (str): The reference string (e.g., ``'my.module.MyClass'`` or a
+                relative reference).
 
         Returns:
-            The resolved path for Nuxt Content (e.g., '/docs/api/my/module/myclass').
+            str: The resolved path for Nuxt Content (e.g., '/docs/api/my/module/myclass').
         """
 
         # For now, we assume all references are fully qualified paths from the root.
@@ -533,7 +623,14 @@ class NuxtRenderer(Renderer):
         self.markdown.init(context)
 
     def _render_page(self, modules: t.List[docspec.Module], page: NuxtPage, filename: str) -> None:
-        """Render a single page to a file."""
+        """Render a single page to a Markdown file.
+
+        Args:
+            modules (t.List[docspec.Module]): List of modules available for
+                rendering.
+            page (NuxtPage): Page configuration describing what to render.
+            filename (str): Destination file path.
+        """
 
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         frontmatter = self._build_frontmatter(modules, page)
@@ -545,7 +642,15 @@ class NuxtRenderer(Renderer):
         self._write_page_file(filename, frontmatter, content)
 
     def _read_source_content(self, page: NuxtPage) -> str:
-        """Read the source file content if specified."""
+        """Read the content of ``page.source`` if specified.
+
+        Args:
+            page (NuxtPage): Page configuration.
+
+        Returns:
+            str: The text from the source file or an empty string if it does not
+            exist.
+        """
         page_source = getattr(page, "source", None)
         if page_source is not None:
             source_path = Path(self._context.directory) / page_source
@@ -556,7 +661,15 @@ class NuxtRenderer(Renderer):
         return ""
 
     def _render_api_content(self, modules: t.List[docspec.Module], page: NuxtPage) -> str:
-        """Render API objects for the page."""
+        """Render API objects configured in the page.
+
+        Args:
+            modules (t.List[docspec.Module]): Available modules.
+            page (NuxtPage): Page configuration.
+
+        Returns:
+            str: Rendered Markdown for the API objects contained in the page.
+        """
         import io
 
         with io.StringIO() as buffer:
@@ -565,7 +678,13 @@ class NuxtRenderer(Renderer):
             return buffer.getvalue()
 
     def _render_page_contents(self, buffer: t.TextIO, modules: t.List[docspec.Module], contents: t.List[str]) -> None:
-        """Helper to render page contents."""
+        """Render the API objects listed in ``contents``.
+
+        Args:
+            buffer (t.TextIO): Buffer to write to.
+            modules (t.List[docspec.Module]): Available modules.
+            contents (t.List[str]): List of module names to render.
+        """
         for content_name in contents:
             module = self._find_module_by_name(modules, content_name)
             if module:
@@ -573,25 +692,54 @@ class NuxtRenderer(Renderer):
                 self._render_module_members(buffer, module)
 
     def _find_module_by_name(self, modules: t.List[docspec.Module], name: str) -> t.Optional[docspec.Module]:
-        """Helper to find a module by name."""
+        """Find a module by name.
+
+        Args:
+            modules (t.List[docspec.Module]): List of modules to search.
+            name (str): Name of the module.
+
+        Returns:
+            t.Optional[docspec.Module]: The matching module or ``None`` if not
+            found.
+        """
         for module in modules:
             if module.name == name:
                 return module
         return None
 
     def _render_module_members(self, buffer: t.TextIO, module: docspec.Module) -> None:
-        """Helper to render module members."""
+        """Render all members of a module.
+
+        Args:
+            buffer (t.TextIO): Buffer to write to.
+            module (docspec.Module): Module whose members will be rendered.
+        """
         for member in module.members:
             self.markdown._render_object(buffer, 2, member)
 
     def _combine_content(self, source_content: str, api_content: str) -> str:
-        """Combine source and API content."""
+        """Combine source markdown with rendered API documentation.
+
+        Args:
+            source_content (str): Markdown from an external file.
+            api_content (str): Markdown generated from API objects.
+
+        Returns:
+            str: The combined Markdown content.
+        """
         if source_content and api_content:
             return source_content + "\n\n" + api_content
         return source_content or api_content
 
     def _write_page_file(self, filename: str, frontmatter: t.Dict[str, t.Any], content: str) -> None:
-        """Write the page file with frontmatter and content."""
+        """Write a Markdown file including YAML frontmatter.
+
+        Args:
+            filename (str): Destination path for the file.
+            frontmatter (t.Dict[str, t.Any]): Dictionary of frontmatter
+                values.
+            content (str): Rendered Markdown content.
+        """
         with open(filename, "w", encoding="utf8") as fp:
             fp.write("---\n")
             fp.write(str(yaml.safe_dump(frontmatter, default_flow_style=False, allow_unicode=True)))
@@ -599,7 +747,16 @@ class NuxtRenderer(Renderer):
             fp.write(content)
 
     def _build_frontmatter(self, modules: t.List[docspec.Module], page: NuxtPage) -> t.Dict[str, t.Any]:
-        """Helper to build the frontmatter dictionary for a page."""
+        """Assemble the frontmatter dictionary for a page.
+
+        Args:
+            modules (t.List[docspec.Module]): List of modules available to
+                render.
+            page (NuxtPage): Page configuration being processed.
+
+        Returns:
+            t.Dict[str, t.Any]: The merged frontmatter dictionary.
+        """
         frontmatter = {**self.default_frontmatter, **page.frontmatter}
         primary_object = modules[0] if len(modules) == 1 else None
 
@@ -631,6 +788,17 @@ class NuxtRenderer(Renderer):
         frontmatter: t.Dict[str, t.Any],
         primary_object: t.Optional[docspec.ApiObject],
     ) -> bool:
+        """Check if a description should be added to frontmatter.
+
+        Args:
+            frontmatter (t.Dict[str, t.Any]): Frontmatter being generated.
+            primary_object (t.Optional[docspec.ApiObject]): Primary API object
+                used for the page.
+
+        Returns:
+            bool: ``True`` if a description should be derived from
+            ``primary_object``.
+        """
         return bool(
             "description" not in frontmatter
             and primary_object
@@ -641,6 +809,18 @@ class NuxtRenderer(Renderer):
     def _build_navigation(
         self, frontmatter: t.Dict[str, t.Any], primary_object: t.Optional[docspec.ApiObject]
     ) -> t.Dict[str, t.Any]:
+        """Build the navigation dictionary for a page.
+
+        Args:
+            frontmatter (t.Dict[str, t.Any]): The frontmatter collected so
+                far.
+            primary_object (t.Optional[docspec.ApiObject]): Primary API object
+                rendered on the page, if any.
+
+        Returns:
+            t.Dict[str, t.Any]: A navigation dictionary suitable for Nuxt
+            Content.
+        """
         navigation_value = frontmatter.get("navigation", {})
         if isinstance(navigation_value, bool):
             # If navigation is True, create a default navigation dict
@@ -659,6 +839,7 @@ class NuxtRenderer(Renderer):
         return navigation
 
     def _get_icon_key(self, primary_object: t.Optional[docspec.ApiObject]) -> str:
+        """Return the icon key for a given API object."""
         if not primary_object:
             return "page"
         if isinstance(primary_object, docspec.Module):
@@ -685,7 +866,12 @@ class NuxtRenderer(Renderer):
             self._render_all_pages(modules, known_files)
 
     def _cleanup_files(self, known_files: KnownFiles) -> None:
-        """Remove previously generated files."""
+        """Remove previously generated files.
+
+        Args:
+            known_files (KnownFiles): Tracker object containing files from the
+                last render.
+        """
         for file_ in known_files.load():
             try:
                 os.remove(file_.name)
@@ -694,7 +880,15 @@ class NuxtRenderer(Renderer):
                 pass
 
     def _get_page_filename(self, item, page):
-        """Helper to determine the filename for a page."""
+        """Determine the output filename for a page.
+
+        Args:
+            item: Page tree node.
+            page (NuxtPage): Page configuration.
+
+        Returns:
+            str: Full path to the output file.
+        """
         if hasattr(page, "directory") and page.directory:
             directory = os.path.join(self.content_directory, page.directory)
             name = page.name if page.name is not None else "index"
@@ -705,7 +899,13 @@ class NuxtRenderer(Renderer):
             return os.path.join(self.content_directory, name + page.extension)
 
     def _render_all_pages(self, modules: t.List[docspec.Module], known_files: KnownFiles) -> None:
-        """Render all pages and track known files."""
+        """Render all configured pages and track generated files.
+
+        Args:
+            modules (t.List[docspec.Module]): List of modules available for
+                rendering.
+            known_files (KnownFiles): Tracker object for generated files.
+        """
         for item in self.pages.iter_hierarchy():
             page = item.page
             filename = self._get_page_filename(item, page)
@@ -715,7 +915,15 @@ class NuxtRenderer(Renderer):
                 logger.info(f"Rendered {filename}")
 
     def get_resolver(self, modules: t.List[docspec.Module]) -> t.Optional[Resolver]:
-        """Get a resolver for cross-references."""
+        """Return a resolver for cross-references.
+
+        Args:
+            modules (t.List[docspec.Module]): Modules that will be rendered.
+
+        Returns:
+            t.Optional[Resolver]: Resolver instance for translating API
+            references to URLs.
+        """
 
         # Determine the base path for URLs, removing the root "content" directory.
         # e.g., if content_directory is "content/docs/api", base_path becomes "docs/api"

--- a/src/pydoc_markdown_nuxt/renderer.py
+++ b/src/pydoc_markdown_nuxt/renderer.py
@@ -496,7 +496,8 @@ class NuxtContentResolver(MarkdownReferenceResolver):
                 relative reference).
 
         Returns:
-            str: The resolved path for Nuxt Content (e.g., '/docs/api/my/module/myclass').
+            t.Optional[str]: The resolved path for Nuxt Content (e.g., '/docs/api/my/module/myclass'),
+            or `None` if the reference cannot be resolved.
         """
 
         # For now, we assume all references are fully qualified paths from the root.

--- a/src/pydoc_markdown_nuxt/utils.py
+++ b/src/pydoc_markdown_nuxt/utils.py
@@ -7,8 +7,15 @@ from typing import Any, Dict, List, Optional
 
 
 def _convert_to_kebab_case(component_name: str) -> str:
-    """
-    Convert component name to kebab-case following Nuxt MDC conventions.
+    """Convert a component name to kebab-case.
+
+    Args:
+        component_name (str): Name of the component in PascalCase or
+            kebab-case.
+
+    Returns:
+        str: The component name converted to kebab-case according to Nuxt MDC
+        conventions.
 
     Examples:
         UAlert -> u-alert
@@ -33,13 +40,14 @@ def create_mdc_alert(content: str, type: str = "info", title: Optional[str] = No
     Create an MDC alert component.
 
     Args:
-        content: The alert content
-        type: Alert type (info, warning, error, success)
-        title: Optional title for the alert
-        component: Component name to use (default: alert)
+        content (str): The alert content.
+        type (str): Alert type (``"info"``, ``"warning"``, ``"error"``,
+            ``"success"``).
+        title (Optional[str]): Optional title for the alert.
+        component (str): Component name to use (default ``"alert"``).
 
     Returns:
-        MDC alert syntax string
+        str: MDC alert syntax string.
     """
     props = f'type="{type}"'
     if title:
@@ -56,11 +64,12 @@ def create_mdc_code_group(code_blocks: List[Dict[str, str]], component: str = "c
     Create an MDC code group with multiple code blocks.
 
     Args:
-        code_blocks: List of dicts with 'language', 'filename', and 'code' keys
-        component: Component name to use (default: code-group)
+        code_blocks (List[Dict[str, str]]): List of dictionaries with
+            ``language``, ``filename`` and ``code`` keys.
+        component (str): Component name to use (default ``"code-group"``).
 
     Returns:
-        MDC code group syntax string
+        str: MDC code group syntax string.
     """
     # Convert component name to kebab-case
     component_name = _convert_to_kebab_case(component)
@@ -88,11 +97,12 @@ def create_mdc_tabs(tabs: List[Dict[str, str]], component: str = "tabs") -> str:
     Create MDC tabs component.
 
     Args:
-        tabs: List of dicts with 'title' and 'content' keys
-        component: Component name to use (default: tabs)
+        tabs (List[Dict[str, str]]): List of dictionaries with ``title`` and
+            ``content`` keys.
+        component (str): Component name to use (default ``"tabs"``).
 
     Returns:
-        MDC tabs syntax string
+        str: MDC tabs syntax string.
     """
     # Convert component name to kebab-case
     component_name = _convert_to_kebab_case(component)
@@ -116,11 +126,12 @@ def create_mdc_variables(variables: List[Dict[str, str]], component: str = "UVar
     Create an MDC variables component.
 
     Args:
-        variables: List of dicts with 'name', 'type', and 'content' keys
-        component: Component name to use (default: UVariables)
+        variables (List[Dict[str, str]]): List of dictionaries with ``name``,
+            ``type`` and ``content`` keys.
+        component (str): Component name to use (default ``"UVariables"``).
 
     Returns:
-        MDC variables syntax string
+        str: MDC variables syntax string.
     """
     # Convert component name to kebab-case
     component_name = _convert_to_kebab_case(component)
@@ -146,11 +157,12 @@ def create_mdc_arguments(arguments: List[Dict[str, str]], component: str = "UArg
     Create an MDC arguments component.
 
     Args:
-        arguments: List of dicts with 'name', 'type', and 'content' keys
-        component: Component name to use (default: UArguments)
+        arguments (List[Dict[str, str]]): List of dictionaries with ``name``,
+            ``type`` and ``content`` keys.
+        component (str): Component name to use (default ``"UArguments"``).
 
     Returns:
-        MDC arguments syntax string
+        str: MDC arguments syntax string.
     """
     # Convert component name to kebab-case
     component_name = _convert_to_kebab_case(component)
@@ -178,12 +190,14 @@ def create_variable_or_argument_component(
     Create either a variables or arguments MDC component.
 
     Args:
-        items: List of dicts with 'name', 'type', and 'content' keys
-        component_type: Either 'variables' or 'arguments'
-        component: Component name to use (auto-detected if None)
+        items (List[Dict[str, str]]): List of dictionaries with ``name``,
+            ``type`` and ``content`` keys.
+        component_type (str): Either ``"variables"`` or ``"arguments"``.
+        component (Optional[str]): Component name to use (auto-detected if
+            ``None``).
 
     Returns:
-        MDC component syntax string
+        str: MDC component syntax string.
     """
     if component is None:
         component = f"U{component_type.capitalize()}"
@@ -203,14 +217,14 @@ def create_navigation_entry(
     Create a navigation entry for Nuxt Content.
 
     Args:
-        title: Navigation title
-        path: Path to the page
-        icon: Optional icon name
-        badge: Optional badge text
-        description: Optional description
+        title (str): Navigation title.
+        path (str): Path to the page.
+        icon (Optional[str]): Optional icon name.
+        badge (Optional[str]): Optional badge text.
+        description (Optional[str]): Optional description.
 
     Returns:
-        Navigation entry dictionary
+        Dict[str, Any]: Navigation entry dictionary.
     """
     entry = {"title": title, "to": path}
 
@@ -229,11 +243,12 @@ def enhance_frontmatter_for_nuxt(frontmatter: Dict[str, Any], page_type: str = "
     Enhance frontmatter with Nuxt Content specific fields.
 
     Args:
-        frontmatter: Base frontmatter dictionary
-        page_type: Type of page (doc, guide, reference, example)
+        frontmatter (Dict[str, Any]): Base frontmatter dictionary.
+        page_type (str): Type of page (``"doc"``, ``"guide"``,
+            ``"reference"``, ``"example"``).
 
     Returns:
-        Enhanced frontmatter dictionary
+        Dict[str, Any]: Enhanced frontmatter dictionary.
     """
     enhanced = frontmatter.copy()
 
@@ -267,11 +282,11 @@ def generate_api_breadcrumbs(module_path: str, base_url: str = "/docs") -> List[
     Generate breadcrumb navigation for API documentation.
 
     Args:
-        module_path: Full module path (e.g., "mypackage.core.DataProcessor")
-        base_url: Base URL for the documentation
+        module_path (str): Full module path (e.g., ``"mypackage.core.DataProcessor"``).
+        base_url (str): Base URL for the documentation.
 
     Returns:
-        List of breadcrumb items
+        List[Dict[str, str]]: List of breadcrumb items.
     """
     breadcrumbs = []
 
@@ -295,10 +310,10 @@ def format_python_signature_for_mdc(signature: str) -> str:
     Format a Python function signature for better display in MDC.
 
     Args:
-        signature: Python function signature string
+        signature (str): Python function signature string.
 
     Returns:
-        Formatted signature with syntax highlighting
+        str: Formatted signature with syntax highlighting.
     """
     # Simple formatting - could be enhanced with more sophisticated parsing
     formatted = signature.replace("(", "(\n  ").replace(", ", ",\n  ").replace(")", "\n)")
@@ -311,10 +326,11 @@ def create_api_overview_table(classes: List[Dict[str, str]]) -> str:
     Create a table overview of API classes.
 
     Args:
-        classes: List of dicts with 'name', 'description', and optional 'link' keys
+        classes (List[Dict[str, str]]): List of dictionaries with ``name``,
+            ``description`` and optional ``link`` keys.
 
     Returns:
-        Markdown table string
+        str: Markdown table string.
     """
     if not classes:
         return ""
@@ -341,6 +357,14 @@ class NuxtContentHelper:
     """
 
     def __init__(self, base_url: str = "/docs", use_mdc: bool = True, mdc_components: Optional[Dict[str, str]] = None):
+        """Initialize the helper.
+
+        Args:
+            base_url (str): Base URL used when generating links.
+            use_mdc (bool): Whether to wrap sections with MDC components.
+            mdc_components (Optional[Dict[str, str]]): Optional mapping of
+                component types to custom MDC component names.
+        """
         self.base_url = base_url
         self.use_mdc = use_mdc
         # Default to Nuxt UI components
@@ -357,20 +381,52 @@ class NuxtContentHelper:
         }
 
     def get_component_name(self, component_type: str) -> str:
-        """Get the configured component name for a component type."""
+        """Get the configured component name for a component type.
+
+        Args:
+            component_type (str): The internal component key (e.g. ``"alert"``).
+
+        Returns:
+            str: The kebab-case name of the component to use.
+        """
         component = self.mdc_components.get(component_type, component_type)
         # Convert component name to kebab-case following MDC conventions
         return _convert_to_kebab_case(component)
 
     def wrap_with_mdc_if_enabled(self, content: str, component_type: str, props: str = "") -> str:
-        """Wrap content with MDC component if MDC is enabled."""
+        """Wrap content with an MDC component if enabled.
+
+        Args:
+            content (str): Markdown content to wrap.
+            component_type (str): Type of component to use from
+                ``mdc_components``.
+            props (str): Optional string of properties to pass to the
+                component.
+
+        Returns:
+            str: The original content wrapped with an MDC component if
+            ``use_mdc`` is ``True``; otherwise the content is returned
+            unchanged.
+        """
         if self.use_mdc:
             component_name = self.get_component_name(component_type)
             return f"::{component_name}{{{props}}}\n{content}\n::"
         return content
 
     def create_hero_section(self, title: str, description: str, links: Optional[List[Dict[str, str]]] = None) -> str:
-        """Create a hero section for documentation pages."""
+        """Create a hero section for documentation pages.
+
+        Args:
+            title (str): Title displayed in the hero section.
+            description (str): Introductory text for the section.
+            links (Optional[List[Dict[str, str]]]): Optional list of link
+                dictionaries. Each dictionary may contain ``label``, ``url`` and
+                ``variant`` keys.
+
+        Returns:
+            str: The rendered hero section in Markdown or MDC format depending
+            on ``use_mdc``.
+        """
         content = f"# {title}\n\n{description}\n"
 
         if links:
@@ -392,7 +448,16 @@ class NuxtContentHelper:
         return content
 
     def create_feature_list(self, features: List[Dict[str, str]]) -> str:
-        """Create a feature list section."""
+        """Create a feature list section.
+
+        Args:
+            features (List[Dict[str, str]]): A list of feature dictionaries
+                containing ``title``, ``description`` and optionally ``icon``
+                keys.
+
+        Returns:
+            str: Markdown or MDC formatted feature list depending on ``use_mdc``.
+        """
         if not features:
             return ""
 
@@ -412,7 +477,15 @@ class NuxtContentHelper:
         return content.strip()
 
     def create_variables_section(self, variables: List[Dict[str, str]]) -> str:
-        """Create a variables section using configured component."""
+        """Create a variables section using the configured component.
+
+        Args:
+            variables (List[Dict[str, str]]): A list of dictionaries defining
+                variables with ``name``, ``type`` and ``content`` keys.
+
+        Returns:
+            str: A Markdown or MDC formatted variables section.
+        """
         if not variables:
             return ""
 
@@ -432,7 +505,15 @@ class NuxtContentHelper:
             return content
 
     def create_arguments_section(self, arguments: List[Dict[str, str]]) -> str:
-        """Create an arguments section using configured component."""
+        """Create an arguments section using the configured component.
+
+        Args:
+            arguments (List[Dict[str, str]]): List of argument dictionaries
+                containing ``name``, ``type`` and ``content`` keys.
+
+        Returns:
+            str: A Markdown or MDC formatted arguments section.
+        """
         if not arguments:
             return ""
 


### PR DESCRIPTION
## Summary
- annotate return types throughout utils and renderer docstrings
- install dependencies so tests run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883c902bb60832ba280393afff11c67